### PR TITLE
Fix version file URL property

### DIFF
--- a/waterdrinker.version
+++ b/waterdrinker.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "WaterDrinker",
-	"URL": "https://raw.githubusercontent.com/Tantares/WaterDrinker/master/waterdrinker.version",
+	"URL": "https://raw.githubusercontent.com/Tantares/WaterDrinker/main/waterdrinker.version",
 	"DOWNLOAD" : "https://github.com/Tantares/WaterDrinker/releases",
 	"GITHUB": {
 		"USERNAME": "Tantares",


### PR DESCRIPTION
Hi @Tantares,

This repo has a `main` branch, but the version file has `master` instead.
This won't affect the GitHub web UI because it has an automatic redirect, but it does cause attempts to retrieve the file via the GitHub API to fail. (CKAN's bot does it this way to avoid getting throttled.)

Now it's fixed.

Noticed while working on KSP-CKAN/NetKAN#9724.
